### PR TITLE
Create AviationCockpits.cfg

### DIFF
--- a/GameData/AJE/Inlets/AviationCockpits.cfg
+++ b/GameData/AJE/Inlets/AviationCockpits.cfg
@@ -16,7 +16,7 @@
 	@MODULE[ModuleResourceIntake]
 	{
 		@name = AJEInlet
-		Area = 0.2313
+		Area = 0.742
 		#@AJE_TPR_CURVE_DEFAULTS/AdjustableSupersonic/TPRCurve {}
 
 		inletTitle = #$@AJE_TPR_CURVE_DEFAULTS/AdjustableSupersonic/title$

--- a/GameData/AJE/Inlets/AviationCockpits.cfg
+++ b/GameData/AJE/Inlets/AviationCockpits.cfg
@@ -1,0 +1,25 @@
+@PART[Mk1?Mirage?Cockpit]:FOR[AJE]
+{
+	@MODULE[ModuleResourceIntake]
+	{
+		@name = AJEInlet
+		Area = 0.59
+		#@AJE_TPR_CURVE_DEFAULTS/FixedCone/TPRCurve {}
+
+		inletTitle = #$@AJE_TPR_CURVE_DEFAULTS/FixedCone/title$
+		inletDescription = #$@AJE_TPR_CURVE_DEFAULTS/FixedCone/description$
+	}
+}
+
+@PART[Typhoon?Cockpit]:FOR[AJE]
+{
+	@MODULE[ModuleResourceIntake]
+	{
+		@name = AJEInlet
+		Area = 0.2313
+		#@AJE_TPR_CURVE_DEFAULTS/AdjustableSupersonic/TPRCurve {}
+
+		inletTitle = #$@AJE_TPR_CURVE_DEFAULTS/AdjustableSupersonic/title$
+		inletDescription = #$@AJE_TPR_CURVE_DEFAULTS/AdjustableSupersonic/description$
+	}
+}


### PR DESCRIPTION
Create configs for Aviation Cockpits with built in intakes. Intake areas measured from scale drawings of Mirage 2000/Eurofighter Typhoon.