### PR TITLE
Mark as 1.3.1 compatible

### DIFF
--- a/GameData/AJE/AJE.version
+++ b/GameData/AJE/AJE.version
@@ -12,9 +12,14 @@
     "PATCH" : 0,
     "BUILD" : 0
   },
-  "KSP_VERSION" : {
+  "KSP_VERSION_MIN" : {
     "MAJOR" : 1,
     "MINOR" : 3,
     "PATCH" : 0
+  },
+  "KSP_VERSION_MAX" : {
+    "MAJOR" : 1,
+    "MINOR" : 3,
+    "PATCH" : 1
   }
 }


### PR DESCRIPTION
This mod is reported to be 1.3.1 compatible:

> https://forum.kerbalspaceprogram.com/index.php?/topic/139868-13-advanced-jet-engine-v290-august-22-throttle-and-ramjet-improvements/&do=findComment&comment=3246705

But its KSP-AVC file currently says 1.3.0 only. This pull request updates it to span 1.3.0 and 1.3.1.