### PR TITLE
Update DB60x.cfg

### DIFF
--- a/GameData/AJE/Parts/Props/DB60x.cfg
+++ b/GameData/AJE/Parts/Props/DB60x.cfg
@@ -18,7 +18,7 @@
 		%maxRPM = 2800
 		%power = 1600//1475
 		%gearratio = 0.594
-		%BSFC = 1.2747-07
+		%BSFC = 1.2747e-07
 		%coolerEffic = 0.325
 		%coolerMin = 0
 		%ramAir = 0


### PR DESCRIPTION
Bad scientific notation, missing 'e'