### PR TITLE
Update V-1650-7.cfg

### DIFF
--- a/GameData/AJE/Parts/Props/V-1650-7.cfg
+++ b/GameData/AJE/Parts/Props/V-1650-7.cfg
@@ -18,7 +18,7 @@
 		%maxRPM = 3000
 		%power = 1601
 		%gearratio = 0.479
-		%BSFC = 1.2747-07
+		%BSFC = 1.2747e-07
 		%coolerEffic = 0.77
 		%coolerMin = 15
 		%ramAir = 1


### PR DESCRIPTION
Bad scientific notation, missing 'e'