### PR TITLE
Rename ramjet area to 'required area' to keep consistent naming

### DIFF
--- a/Source/AJERamjet.cs
+++ b/Source/AJERamjet.cs
@@ -119,7 +119,7 @@ namespace AJE
         public override string GetInfo()
         {
             string output = "<b>Max Rated Thrust:</b> " + thrustUpperLimit.ToString("N2") + " kN\n";
-            output += "<b>Area:</b> " + Area + "\n";
+            output += "<b>Required Area:</b> " + Area + " m^2\n";
 
             output += "\n<b><color=#99ff00ff>Propellants:</color></b>\n";
             Propellant p;


### PR DESCRIPTION
Currently, turbojets have a "Required Area", while ramjets have an "Area". This leads to potential confusion (as seen [here](https://discord.com/channels/319857228905447436/1115321536807718992/1360810475071475772) from exe.txt), as they are the same concept described differently. Additionally, the ramjet info is missing units for the area.

![image](https://github.com/user-attachments/assets/6ce143b6-63c9-487d-be84-f749d8fa170d)
![image](https://github.com/user-attachments/assets/0dac3f13-47fd-4cf1-b79c-b4843ced2da0)
